### PR TITLE
Updates to checklist and release status template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -142,7 +142,6 @@ Release Week Checklist:
 - [ ] **Generate The Release Notes Per JDK Version **, ( Use https://ci.adoptium.net/job/build-scripts/job/release/job/create_release_notes/ ) and publish them with the [release tool](https://ci.adoptium.net/job/build-scripts/job/release/job/refactor_openjdk_release_tool/) using `UPSTREAM_JOB_NAME` of `create_release_notes` and the appropriate JOB NUMBER
 - [ ] **Verify that the release notes are live - may require a full update on the API [ we've had problems with this recently](https://github.com/adoptium/temurin/issues/28#issuecomment-2077786176)) and remediate if required.
 - [ ] **Publish the release** (run the restricted access [release tool job](https://ci.adoptopenjdk.net/job/build-scripts/job/release/job/refactor_openjdk_release_tool/) on Jenkins) ( also publish release notes )
-- [ ] **Consider updating the API** as required via the relevant parts of [the Adoptium API model constants](https://github.com/adoptium/api.adoptium.net/blob/main/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/models/Versions.kt).
 - [ ] **Verify binaries published successfully** to github releases repo and website (_automate_*, this could also be an automated test)
 
 - [ ] **Publish updates to the containers to dockerhub**

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -155,7 +155,7 @@ Release Week Checklist:
 - [ ] **Declare code freeze end** opening up the code for further development
 - [ ] **Disable code freeze bot** In order to enable the code freeze GitHub you need to change the line `if: github.repository_owner == 'adoptium' && true` to be `if: github.repository_owner == 'adoptium' && false` in the [code-freeze.yml](https://github.com/adoptium/.github/blob/main/.github/workflows/code-freeze.yml#L21) GitHub workflow. Please contact the PMC if you need help merging this change.
 - [ ] **Remove website banner** (_automate_* via github workflow in website repository)
-- [ ] **Check for presence of jdk8u aarch32 GA tag and mirror it** [Mercurial repo](https://hg.openjdk.java.net/aarch32-port/jdk8u) - [Mirror job](https://ci.adoptopenjdk.net/view/git-mirrors/job/git-mirrors/job/adoptium/job/git-hg-aarch32-jdk8u/)
+- [ ] **Check for presence of jdk8u aarch32 GA tag and mirror it** [Upstream Git repo](https://github.com/openjdk/aarch32-port-jdk8u) - [Mirror job](https://ci.adoptium.net/view/git-mirrors/job/git-mirrors/job/adoptium/job/git-skara-aarch32-jdk8u/)
 - [ ] **Do all of the above for the jdk8u/aarch32 build: Ensure to specify overridePublishName param**
 - [ ] **Archive/upload all TCK results**
 - [ ] **Use EclipseMirror job in the Temurin Compliance jenkins to store a backup** of the release artifacts

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -146,7 +146,7 @@ Release Week Checklist:
 - [ ] **Verify binaries published successfully** to github releases repo and website (_automate_*, this could also be an automated test)
 
 - [ ] **Publish updates to the containers to dockerhub**
-- [ ] **Edit the [Homebrew Temurin Cask](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/temurin.rb)** and replace the version and sha256 as appropriate.  This means for Homebrew users that they install the latest by default and can use the `@` notation to install older versions if they wish.
+- [ ] **Edit the [Homebrew Temurin Cask](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/t/temurin.rb)** and replace the version and sha256 as appropriate.  This means for Homebrew users that they install the latest by default and can use the `@` notation to install older versions if they wish.
 - [ ] **Update support page** (_automate_* github workflow to create a PR to update the versions and dates on the [support table](https://github.com/adoptium/adoptium.net/blob/main/content/asciidoc-pages/support/_partials/support-table.adoc))
 - [ ] **Update supported platforms tables if needed** if they have changed in this release. Create a PR to [Supported platforms](https://github.com/adoptium/adoptium.net/blob/main/content/asciidoc-pages/supported-platforms/index.adoc)
 - [ ] **Update release notes** (_automate_* - github workflow to create update for release notes pages - [example](https://adoptium.net/temurin/release-notes/?version=jdk8u382-b05))

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -31,6 +31,7 @@ Everyone participating in a release, including the release champion are requeste
 - [ ] **Notify release branching of build repositories** : [Slack message, branching build repositories](https://github.com/adoptium/temurin-build/blob/master/RELEASING.md#branching-message-for-build-related-repositories)
 - [ ] **Create build repositories release Branches** : [Create build repository release branches](https://github.com/adoptium/temurin-build/blob/master/RELEASING.md#create-release-branch-on-below-repositories)
 - [ ] **Identify the aqa branch name for the upcoming release (Note, April and October PSU updates generally use same branch as the March/September new releases**
+- [ ] **Check that the [temurin updater action](https://github.com/adoptium/marketplace-data/actions/workflows/temurin-updater.yml) has not been suspended. If it has, re-enable it or set a reminder to run manually when ready. 
 
 ### 1-1½ weeks prior to release
 

--- a/.github/ISSUE_TEMPLATE/release-status.md
+++ b/.github/ISSUE_TEMPLATE/release-status.md
@@ -78,7 +78,7 @@ Sharing information in this issue since the TCK work is being tracked in temurin
 | riscv64 Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: | This will be a headless build |
 
 ### JDK23.0.X+Y
-| Platform  | jdk21 AQA | jdk21 TCK | jdk21 published| jdk21 installers | jdk21 images  | Notes |
+| Platform  | jdk23 AQA | jdk23 TCK | jdk23 published| jdk23 installers | jdk23 images  | Notes |
 | -----     | -----     | -----     | -----          | -----            | -----         | ----- |
 | **x64 Linux** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
 | **x64 Windows** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |

--- a/.github/ISSUE_TEMPLATE/release-status.md
+++ b/.github/ISSUE_TEMPLATE/release-status.md
@@ -9,83 +9,85 @@ assignees: ''
 
 Sharing information in this issue since the TCK work is being tracked in temurin-compliance private repo not visible to the community (as per the OCTLA).  Risks and expectations for timing on the release are listed in this [issue comment](https://github.com/adoptium/adoptium/issues/3#issuecomment-866903922).  Primary platforms (x64 Linux/Windows/OSX and aarch64 Linux/OSX) in **bold** are prioritized, secondary platforms not in bold follow in no particular order (as machine resources are available).  We retrospectively measure and track how well we do against these targets in these [Adoptium Release Scorecards](https://github.com/adoptium/adoptium/wiki/Adoptium-Release-Scorecards) in order to continuously assess and improve.
 
-✔️ results in these Tables means the activity has successfully completed.
+:heavy_check_mark: results in these Tables means the activity has successfully completed.
 
-⏳ results means that we are actively working on closing off the runs needed for this version, platform, binaryType.
+:hourglass_flowing_sand: results means that we are actively working on closing off the runs needed for this version, platform, binaryType.
 
-⛔ means there is no build planned for that version/platform combination.
+ :no_entry: means there is no build planned for that version/platform combination.
 
-⏸️ means activity not yet started.
+ :pause_button: means activity not yet started.
 
 ### JDK8uXXX-bXX
 | Platform  | jdk8 AQA  | jdk8 TCK  | jdk8 published | jdk8 installers  | jdk8 images   | Notes |
 | -----     | -----     | -----     | -----          | -----            | -----         | ----- |
-| **x64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| **x64 Windows** | ⏸️   | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| **x64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔            |       |
-| **aarch64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| ppcle64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| ppc64 AIX | ⏸️         | ⏸️         | ⏸️              | ⛔               | ⛔            |       |
-| x32 Windows | ⏸️       | ⏸️         | ⏸️              | ⛔               | ⏸️             |       |
-| arm32 Linux | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| x64 alpine-Linux | ⏸️  | ⏸️         | ⏸️              | ⏸️                | ⏸️             | This will be a headless build |
-| sparcv9 solaris | ⏸️   | ⏸️         | ⏸️              | ⛔               | ⛔            |       |
-| x86 solaris | ⏸️       | ⏸️         | ⏸️              | ⛔               | ⛔            |       |
+| **x64 Linux**     | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **x64 Windows**   | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **x64 Mac**       | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :no_entry: |       |
+| **aarch64 Linux** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| ppcle64 Linux     | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| ppc64 AIX         | :pause_button: | :pause_button: | :pause_button: | :no_entry: | :no_entry: |       |
+| x32 Windows       | :pause_button: | :pause_button: | :pause_button: | :no_entry: | :pause_button: |       |
+| arm32 Linux       | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| x64 alpine-Linux  | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: | This will be a headless build |
+| sparcv9 solaris   | :pause_button: | :pause_button: | :pause_button: | :no_entry: | :no_entry: |       |
+| x86 solaris       | :pause_button: | :pause_button: | :pause_button: | :no_entry: | :no_entry: |       |
 
 ### JDK11.0.XX+Y
 | Platform | jdk11 AQA | jdk11 TCK  | jdk11 published| jdk11 installers | jdk11 images  | Notes |
 | -----    | -----     | -----      | -----          | -----            | -----         | ----- |
-| **x64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| **x64 Windows** | ⏸️   | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| **x64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔            |       |
-| **aarch64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| **aarch64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔            |       |
-| ppcle64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| s390x Linux   | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| ppc64 AIX | ⏸️         | ⏸️         | ⏸️              | ⛔               | ⛔            |       |
-| x32 Windows | ⏸️       | ⏸️         | ⏸️              | ⏸                | ⛔            |       |
-| arm32 Linux | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| x64 alpine-Linux | ⏸️  | ⏸️         | ⏸️              | ⏸️                | ⏸️             | This will be a headless build |
+| **x64 Linux** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **x64 Windows** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **x64 Mac** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :no_entry: |       |
+| **aarch64 Linux** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **aarch64 Mac** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :no_entry: |       |
+| ppcle64 Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| s390x Linux   | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| ppc64 AIX | :pause_button: | :pause_button: | :pause_button: | :no_entry: | :no_entry: |       |
+| x32 Windows | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :no_entry: |       |
+| arm32 Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| x64 alpine-Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: | This will be a headless build |
 
 ### JDK17.0.XX+Y
 | Platforms | jdk17 AQA | jdk17 TCK | jdk17 published| jdk17 installers | jdk17 images | Notes |
 | -----     | -----     | -----     | -----          | -----            | -----        | ----- |
-| **x64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
-| **x64 Windows** | ⏸️   | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
-| **x64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔           |       |
-| **aarch64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
-| **aarch64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔           |       |
-| ppcle64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
-| s390x Linux   | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
-| ppc64 AIX | ⏸️         | ⏸️         | ⏸️              | ⛔               | ⛔           |       |
-| x32 Windows | ⏸️       | ⏸️         | ⏸️              | ⏸                | ⛔           |       |
-| arm32 Linux | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
-| x64 alpine-Linux | ⏸️  | ⏸️         | ⏸️              | ⏸️                | ⏸️            | This will be a headless build |
+| **x64 Linux** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **x64 Windows** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **x64 Mac** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :no_entry: |       |
+| **aarch64 Linux** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **aarch64 Mac** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :no_entry: |       |
+| ppcle64 Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| s390x Linux   | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| ppc64 AIX | :pause_button: | :pause_button: | :pause_button: | :no_entry: | :no_entry: |       |
+| x32 Windows | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :no_entry: |       |
+| arm32 Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| x64 alpine-Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: | This will be a headless build |
 
 ### JDK21.0.X+Y
 | Platform  | jdk21 AQA | jdk21 TCK | jdk21 published| jdk21 installers | jdk21 images  | Notes |
 | -----     | -----     | -----     | -----          | -----            | -----         | ----- |
-| **x64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| **x64 Windows** | ⏸️   | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| **x64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔            |       |
-| **aarch64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| **aarch64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔           |       |
-| ppcle64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| s390x Linux   | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| ppc64 AIX | ⏸️         | ⏸️         | ⏸️              | ⛔               | ⛔            |       |
-| x64 alpine-Linux | ⏸️  | ⏸️         | ⏸️              | ⏸️                | ⏸️             | This will be a headless build |
-| riscv64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             | This will be a headless build |
+| **x64 Linux** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **x64 Windows** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **x64 Mac** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :no_entry: |       |
+| **aarch64 Linux** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **aarch64 Mac** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :no_entry: |       |
+| ppcle64 Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| s390x Linux   | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| ppc64 AIX | :pause_button: | :pause_button: | :pause_button: | :no_entry: | :no_entry: |       |
+| aarch64 alpine-Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: | This will be a headless build |
+| x64 alpine-Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: | This will be a headless build |
+| riscv64 Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: | This will be a headless build |
 
-### JDK22.0.X+Y
+### JDK23.0.X+Y
 | Platform  | jdk21 AQA | jdk21 TCK | jdk21 published| jdk21 installers | jdk21 images  | Notes |
 | -----     | -----     | -----     | -----          | -----            | -----         | ----- |
-| **x64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| **x64 Windows** | ⏸️   | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| **x64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔            |       |
-| **aarch64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| **aarch64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔           |       |
-| ppcle64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| s390x Linux   | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
-| ppc64 AIX | ⏸️         | ⏸️         | ⏸️              | ⛔               | ⛔            |       |
-| x64 alpine-Linux | ⏸️  | ⏸️         | ⏸️              | ⏸️                | ⏸️             | This will be a headless build |
-| riscv64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             | This will be a headless build |
+| **x64 Linux** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **x64 Windows** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **x64 Mac** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :no_entry: |       |
+| **aarch64 Linux** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| **aarch64 Mac** | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :no_entry: |       |
+| ppcle64 Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| s390x Linux   | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: |       |
+| ppc64 AIX | :pause_button: | :pause_button: | :pause_button: | :no_entry: | :no_entry: |       |
+| aarch64 alpine-Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: | This will be a headless build |
+| x64 alpine-Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: | This will be a headless build |
+| riscv64 Linux | :pause_button: | :pause_button: | :pause_button: | :pause_button: | :pause_button: | This will be a headless build |


### PR DESCRIPTION
Various updates to the checklist and release status template, including:
- Adding aarch alpine-Linux to jdk21+ in the release status template
- Adding jdk23 to the release status template
- Updating aarch32 jdk8u upstream source repo link and mirror job link in release checklist
- Remove expired reference to Adoptium API Model Constants from release checklist
- Add temurin-updater check to release checklist
- Misc tidying