### PR TITLE
Add download and SBOM validation job to release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -172,6 +172,7 @@ Release Week Checklist:
 - [ ] **Archive/upload all TCK results**
 - [ ] **Archive/upload all AQA results** Search for `Publish AQA test results` in [RELEASING.md](https://github.com/adoptium/temurin-build/blob/master/RELEASING.md) for the process.
 - [ ] **Use EclipseMirror job in the Temurin Compliance jenkins to store a backup** of the release artifacts
+- [ ] **Run download_and_sbom_validation job** to verify the downloads, signatures and SBOM contents.
 - [ ] **Create an issue to capture notes for the next release blog** in the [adoptium.net](https://github.com/adoptium/adoptium.net/issues) repository and ensure to delegate the task of finalizing and publishing a PR for this release's blog post. (Use [this link](https://openjdk.org/groups/vulnerability/advisories) to get the vulnerability list).
 - [ ] **Ensure the [adoptium calendar](https://calendar.google.com/calendar/u/0/embed?src=c_56d7263c0ceda87a1678f6144426f23fb53721480b5ff71b073afb51091e5492@group.calendar.google.com) is updated for the next cycle at a minimum**
 - [ ] **Declare the release complete** and close this issue


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin/issues/72

Should probably have https://github.com/adoptium/temurin-build/pull/4153 merged first since the job won't fully pass without it.