### PR TITLE
add 'release champion only' to release template titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,5 +1,5 @@
 ---
-name: Release Checklist
+name: Release Checklist (For deployment by Release Champions only)
 about: Issue template for release champion and team to track release progress
 title: Checklist for Temurin Release <x>
 labels: ''

--- a/.github/ISSUE_TEMPLATE/release-status.md
+++ b/.github/ISSUE_TEMPLATE/release-status.md
@@ -1,5 +1,5 @@
 ---
-name: Release Status
+name: Release Status (For deployment by Release Champions only)
 about: Issue template for the status document that we direct our customers to during a release cycle
 title: <month> <year> Release Status per Platform, Version & Binary Type
 labels: ''


### PR DESCRIPTION
To avoid any misunderstandings as a "soft" initial solution for the problem described in https://github.com/adoptium/.eclipsefdn/issues/97