### PR TITLE
Initial list of Temurin maintainers

### DIFF
--- a/Maintainers.md
+++ b/Maintainers.md
@@ -1,0 +1,144 @@
+## Maintainers
+
+This document contains a list of individuals known to be directly involved in the operation of the Adoptium project.
+
+### Source control
+
+Committers in named Adoptium GitHub repositories.
+
+Their role and responsibilities are defined in the "Committers" section of the [Eclipse Standard Top Level Charter][estlc].
+
+[estlc]: https://www.eclipse.org/projects/dev_process/Eclipse_Standard_TopLevel_Charter_v1.2.php
+
+- ci-jenkins-pipelines, temurin-build, and installers (GitHub team: adoptium-temurin-committers)
+  - Adam Farley (adamfarley)
+  - Andrew Leonard (andrew-m-leonard)
+  - Derek Keeler (d3r3kk)
+  - George Adams (gdams)
+  - Haroon Khel (Haroon-Khel)
+  - Hendrik Ebbers (hendrikebbers)
+  - John Oliver (johnoliver)
+  - Martijn Verburg (karianna)
+  - Morgan Davies (M-Davies)
+  - Nick Ebbitt (nickebbitt)
+  - Philippe Doussot (douph1)
+  - Scott Fryer (steelhead31)
+  - Severin Gehwolf (jerboaa)
+  - Shelley Lambert (smlambert)
+  - Simon Rushton (lumpfish)
+  - Sophia Guo (sophia-guo)
+  - Stewart X Addison (sxa)
+  - Tim Ellison (tellison)
+  - Wen Zhou (zdtsw)
+  - Will Parker (Willsparker)
+- adoptium.net (GitHub team: adoptium.net-collaborators)
+  - Christopher Guindon (chrisguindon)
+  - George Adams (gdams)
+  - Hendrik Ebbers (hendrikebbers)
+  - Martijn Verburg (karianna)
+  - Shelley Lambert (smlambert)
+  - Stewart X Addison (sxa)
+  - Tim Ellison (tellison)
+  - Xavier FACQ (xavierfacq)
+
+Sources:
+- https://github.com/orgs/adoptium/teams/adoptium-temurin-committers
+- https://github.com/orgs/adoptium/teams/adoptium-net-collaborators
+
+### Jenkins
+
+People with execute/edit access to Jenkins.
+
+Their role is to run, monitor, and maintain build pipeline execution for early access (ea) and release builds.
+
+- Adam Farley (adamfarley)
+- Adam Brousseau (AdamBrousseau)
+- Andreas Ahlenstorf (aahlenst)
+- Andrew Leonard (andrew-m-leonard)
+- Antonio Vieiro (vieiro)
+- Archana Nogriya (archanaNogriya)
+- Austin Bailey (austin0)
+- Beth Griggs (BethGriggs)
+- Charlie Gracie (charliegracie)
+- Dave Hobbs (davehobbs)
+- Derek Keeler (d3r3kk)
+- Dinakar Guniguntala (dinogun)
+- Feilong Jiang (feilongjiang)
+- George Adams (gdams)
+- Haroon Khel (Haroon-Khel)
+- Hendrik Ebbers (hendrikebbers)
+- Jie Kang (jiekang)
+- John Oliver (johnoliver)
+- Juan Antonio Breña Moral (jabrena)
+- Junyuan Zheng (junyuanz1)
+- Lan Xia (llxia)
+- Ludovic Henry (luhenry)
+- Martijn Verburg (karianna)
+- Michael Felt (aixtools)
+- Morgan Davies (M-Davies)
+- Patrick Reinhart (reinhapa)
+- Philippe Doussot (douph1)
+- Radek Cap (RadekCap)
+- Scott Fryer (steelhead31)
+- Severin Gehwolf (jerboaa)
+- Shelley Lambert (smlambert)
+- Simon Rushton (lumpfish)
+- Stephanie Crater (calderast)
+- Stewart X Addison (sxa)
+- Tim Ellison (tellison)
+- Wen Zhou (zdtsw)
+- Will Parker (Willsparker)
+- Sophia Guo (sophia-guo)
+- 张一鹏 (eapenzhan)
+
+Sources:
+- https://github.com/orgs/AdoptOpenJDK/teams/build
+- https://github.com/orgs/AdoptOpenJDK/teams/build-core
+- https://github.com/orgs/AdoptOpenJDK/teams/build-triage
+- https://github.com/orgs/AdoptOpenJDK/teams/build-release
+- https://github.com/orgs/AdoptOpenJDK/teams/jenkins-admins
+
+### Infrastructure
+
+People with direct access to any of our infrastructure.
+
+Their role is to maintain and administrate the infrastructure at the Adoptium project.
+
+- George Adams (gdams)
+- Haroon Khel (Haroon-Khel)
+- John Oliver (johnoliver)
+- Martijn Verburg (karianna)
+- Scott Fryer (steelhead31)
+- Stewart X Addison (sxa)
+
+Source:
+- https://github.com/adoptium/infrastructure#infrastructure-core
+
+### Secrets
+
+People with any level of access to secrets (such as cryptographic keys).
+
+Their role is to ensure secrets are kept up-to-date and used appropriately in the project,
+while preventing them from being shared publicly.
+
+- Alessia Nardotto (AleNard)
+- George Adams (gdams)
+- Haroon Khel (Haroon-Khel)
+- Hendrik Ebbers (hendrikebbers)
+- Ioana Iliescu (iliescuioana)
+- John Oliver (johnoliver)
+- Lukas Pühringer (lukpueh)
+- Martijn Verburg (karianna)
+- Mikaël Barbero (mbarbero)
+- Miruna Sandor (Miru5)
+- Scott Fryer (steelhead31)
+- Severin Gehwolf (jerboaa)
+- Shelley Lambert (smlambert)
+- Stewart X Addison (sxa)
+- Tim Ellison (tellison)
+- Sebastien Heurtematte (heurtematte)
+
+Sources:
+- https://github.com/orgs/adoptium/teams/adoptium-temurin-security
+- https://github.com/orgs/adoptium/teams/eclipsefdn-security
+- https://github.com/orgs/AdoptOpenJDK/teams/infrastructure-core


### PR DESCRIPTION
As part of our efforts to become [OpenSSF Baseline Level 2](https://github.com/adoptium/adoptium/issues/267) compliant, I've created a source-controlled list of project maintainers to satisfy these controls:
- [OSPS-GV-01.01](https://baseline.openssf.org/versions/2025-10-10#osps-gv-0101)
- [OSPS-GV-01.02](https://baseline.openssf.org/versions/2025-10-10#osps-gv-0102)